### PR TITLE
Release 2.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for lgr-django
 
+## 2.0.1 (2019-08-01)
+### Improvements
+- Mark out-of-script codepoints as warnings instead of errors (Fixes icann/lgr-core#15).
+
 ## 2.0.0 (2018-09-06)
 ### New features
 - Support of Python 3. Compatibility with python2 is preserved for this release.

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -9,7 +9,7 @@ redis==2.10.6
 # LGR/Unicode modules
 picu==1.0
 munidata==2.0.0
-lgr-core==2.0.0
+lgr-core==2.0.1
 
 # Natural sorting implementation
 natsort==5.0.3

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,6 +4,7 @@ django-widget-tweaks==1.4.1
 django-multiupload==0.5.2
 celery[redis]==3.1.23
 django-redis-cache==1.7.1
+redis==2.10.6
 
 # LGR/Unicode modules
 picu==1.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from io import open
 
 setup(
     name='lgr-django',
-    version='2.0.0',
+    version='2.0.1',
     author='Viagenie and Wil Tan',
     author_email='support@viagenie.ca',
     packages=find_packages('src'),

--- a/src/lgr_editor/templates/lgr_editor/validate_lgr/rebuild_lgr.html
+++ b/src/lgr_editor/templates/lgr_editor/validate_lgr/rebuild_lgr.html
@@ -3,11 +3,14 @@
 
 {% block result_contents %}
   {% if result.repertoire %}
-    <h4>Invalid characters</h4>
+    <h4>Possibly erroneous characters</h4>
     <ul>
       {% for char, entries in result.repertoire.items %}
-        <li>Invalid character {{ char|render_char }}:
+        <li>Character {{ char|render_char }}:
           <ul>
+            {% for warning in entries.warnings %}
+              <li>Warning: {{ warning|exc_to_text }}</li>
+            {% endfor %}
             {% for error in entries.errors %}
               <li>Error: {{ error|exc_to_text }}</li>
             {% endfor %}


### PR DESCRIPTION
Minor release fixing icann/lgr-core#15:
- Mark out-of-script codepoints as warnings instead of errors.