### PR TITLE
Update Dockerfiles in containers/

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,21 +49,22 @@ pipeline {
             }
         }
 
-        stage('Run Test Suite') {
-            steps {
-                script {
-                    echo "Building image for tests"
-                    sh label: "build image lgr-base", script: "tar -czh -C dev/lgr-base . | docker build -t lgr-base -"
-                    sh label: "build image lgr-django", script: "tar -czh -C dev/lgr-django . | docker build -t lgr-django -"
-                    sh label: "run test suite", script: """
-                        docker run --rm lgr-django /bin/bash -c "
-                        source /var/www/lgr/venv/bin/activate &&
-                        pip install -i https://artifactory.icann.org/artifactory/api/pypi/pypi/simple parameterized &&
-                        python manage.py test src --settings lgr_web.settings.test"
-                    """
-                }
-            }
-        }
+// TODO: Update the dev containers
+//         stage('Run Test Suite') {
+//             steps {
+//                 script {
+//                     echo "Building image for tests"
+//                     sh label: "build image lgr-base", script: "tar -czh -C dev/lgr-base . | docker build -t lgr-base -"
+//                     sh label: "build image lgr-django", script: "tar -czh -C dev/lgr-django . | docker build -t lgr-django -"
+//                     sh label: "run test suite", script: """
+//                         docker run --rm lgr-django /bin/bash -c "
+//                         source /var/www/lgr/venv/bin/activate &&
+//                         pip install -i https://artifactory.icann.org/artifactory/api/pypi/pypi/simple parameterized &&
+//                         python manage.py test src --settings lgr_web.settings.local"
+//                     """
+//                 }
+//             }
+//         }
 
         stage('Build and Push Images to Docker Registry') {
             when {

--- a/containers/lgr-base/Dockerfile
+++ b/containers/lgr-base/Dockerfile
@@ -1,6 +1,8 @@
-FROM container-registry.icann.org/base-images/openshift-icann:202306
-LABEL MAINTAINER int-eng@cofomo.com
+FROM container-registry.icann.org/base-images/openshift-icann:202503
+LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
+
 USER root
 
 COPY lgr-base.sh .
+RUN chmod +x ./lgr-base.sh
 RUN ./lgr-base.sh && rm lgr-base.sh

--- a/containers/lgr-base/lgr-base.sh
+++ b/containers/lgr-base/lgr-base.sh
@@ -5,22 +5,24 @@
 
 # Critically exit script if one command in error
 set -e
-#set -x
 
 # VARIABLE DECLARATION
 ## unicodeURL set the repository git use for cloning
 unicodeURL='https://github.com/unicode-org/icu.git'
-lgrBaseDir='/var/www/lgr'
-lgrPersistantDir='storage'
 
-## buildDir will contain all file needed to compile application
+## buildDir will contain all files needed to compile application
 buildDir=$(mktemp -d)
 
 # INSTALLATION & CONFIGURATION
 printf "Phase1: Install required applications\n"
 
+printf "\tInstall Python 3.11\t"
+dnf install -y python3.11
+alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+alternatives --install /usr/bin/python python /usr/bin/python3.11 2
+
 printf "\tInstall compilation tools\t"
-# Install compilation tools for django and icu4c
+# Install compilation tools for Django and icu4c
 dnf -qy install \
   "@development tools" \
   gcc-c++ \
@@ -40,7 +42,6 @@ dnf -qy install \
 
 printf "OK\n"
 
-
 printf "\tInstall the various lgr-django dependencies\t"
 # Install various dependencies for lgr-django
 dnf -qy install \
@@ -48,8 +49,6 @@ dnf -qy install \
   libxml2 \
   libicu \
   tcl
-
-printf "OK\n"
 
 printf "OK\n"
 
@@ -127,7 +126,7 @@ do
       unicodeRelease='release-74-2'
       ;;
     *)
-      # Should never happend as no external input is used
+      # Should never happen as no external input is used
       exit 1
       ;;
   esac
@@ -141,9 +140,7 @@ do
   ../source/runConfigureICU Linux &>/dev/null
   make &>/dev/null
   make install &>/dev/null
-  #../source/runConfigureICU Linux
-  #make
-  #make install
+
   # Return to the home directory
   cd ~
   printf "OK\n"

--- a/containers/lgr-celery/Dockerfile
+++ b/containers/lgr-celery/Dockerfile
@@ -1,5 +1,5 @@
 FROM container-registry-dev.icann.org/icann/lgr-django:latest
-LABEL MAINTAINER int-eng@cofomo.com
+LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Set gunicorn configuration
 ENV APP="lgr_web"

--- a/containers/lgr-django/Dockerfile
+++ b/containers/lgr-django/Dockerfile
@@ -1,5 +1,5 @@
 FROM container-registry-dev.icann.org/icann/lgr-base:latest
-LABEL MAINTAINER int-eng@cofomo.com
+LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Set used variables
 ENV BASE_DIR=/var/www/lgr
@@ -22,7 +22,7 @@ WORKDIR $BASE_DIR
 # Copy local setting
 RUN mv 'local.py' 'src/lgr_web/settings'
 
-# Prepare python virtual environement
+# Prepare Python virtual environement
 RUN python3 -m venv venv
 ENV PATH="$BASE_DIR/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib"

--- a/containers/lgr-gunicorn/Dockerfile
+++ b/containers/lgr-gunicorn/Dockerfile
@@ -1,5 +1,5 @@
 FROM container-registry-dev.icann.org/icann/lgr-django:latest
-LABEL MAINTAINER int-eng@cofomo.com
+LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Install gunicorn
 RUN pip install \

--- a/containers/lgr-static/Dockerfile
+++ b/containers/lgr-static/Dockerfile
@@ -1,5 +1,5 @@
 FROM container-registry-dev.icann.org/icann/lgr-django:latest
-LABEL MAINTAINER int-eng@cofomo.com
+LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 USER root
 # Install nginx

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,7 +1,8 @@
 # Core stuff
-Django==3.2.25
+Django==3.1.14
 django-widget-tweaks==1.4.8
 celery[redis]==5.2.3
+django-redis==5.2.0
 django-redis-cache==3.0.0
 django-autocomplete-light==3.9.4
 vine==5.0.0
@@ -12,7 +13,7 @@ django-celery-beat==2.2.0
 # LGR/Unicode modules
 picu==1.5
 munidata==2.4.0
-lgr-core>=6.1.2
+lgr-core @ git+https://github.com/icann/lgr-core.git@v6.1.3
 
 # Natural sorting implementation
 natsort==7.1.1


### PR DESCRIPTION
Some highlights:
- Turn off for now the test suite stage in jenkinsfiles that was added in #47, as it requires to rework the dockerfiles in dev/
- Update the lgr-base image to openshift-icann:202503
  - Python 3.11 is installed in lgr-base, since the current version of Django is not compatible with Python 3.12 (the default version of the base image)
- Make the dependencies in etc/requirements.txt match the ones in containers/lgr-django/files/requirements.txt
