### PR TITLE
Fix: Fetch the base images in artifactory

### DIFF
--- a/containers/lgr-celery/Dockerfile
+++ b/containers/lgr-celery/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry-dev.icann.org/icann/lgr-django:latest
+FROM lgr-django:latest
 LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Set gunicorn configuration

--- a/containers/lgr-django/Dockerfile
+++ b/containers/lgr-django/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry-dev.icann.org/icann/lgr-base:latest
+FROM lgr-base:latest
 LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Set used variables

--- a/containers/lgr-gunicorn/Dockerfile
+++ b/containers/lgr-gunicorn/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry-dev.icann.org/icann/lgr-django:latest
+FROM lgr-django:latest
 LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 # Install gunicorn

--- a/containers/lgr-static/Dockerfile
+++ b/containers/lgr-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry-dev.icann.org/icann/lgr-django:latest
+FROM lgr-django:latest
 LABEL org.opencontainers.image.authors="int-eng@cofomo.com"
 
 USER root

--- a/helm/values/values-prod-dc.yaml
+++ b/helm/values/values-prod-dc.yaml
@@ -31,7 +31,7 @@ lgr:
 
   IcannAuthUrl: https://account.icann.org
 
-repoPath: container-registry.icann.org/icann
+repoPath: artifactory.icann.org/docker/icann
 repoVer: latest
 
 microservices:

--- a/helm/values/values-prod-lax.yaml
+++ b/helm/values/values-prod-lax.yaml
@@ -31,7 +31,7 @@ lgr:
 
   IcannAuthUrl: https://account.icann.org
 
-repoPath: container-registry.icann.org/icann
+repoPath: artifactory.icann.org/docker/icann
 repoVer: latest
 
 microservices:

--- a/helm/values/values-qa.yaml
+++ b/helm/values/values-qa.yaml
@@ -30,7 +30,7 @@ lgr:
 
   IcannAuthUrl: https://accounts-qa.icann.org
 
-repoPath: container-registry-dev.icann.org/icann
+repoPath: artifactory.icann.org/docker/icann
 repoVer: latest
 
 microservices:


### PR DESCRIPTION
In [our Jenkins pipeline](https://github.com/icann/lgr-django/blob/master/Jenkinsfile#L27), we are pushing the new images to `artifactory.icann.org/docker`