### PR TITLE
Fix: Have lgr-django dockerfile use Python 3.11 for the venv

### DIFF
--- a/containers/lgr-django/Dockerfile
+++ b/containers/lgr-django/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR $BASE_DIR
 RUN mv 'local.py' 'src/lgr_web/settings'
 
 # Prepare Python virtual environement
-RUN python3 -m venv venv
+RUN python -m venv venv
 ENV PATH="$BASE_DIR/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 


### PR DESCRIPTION
In #49, the base image for lgr-base was updated. Since the default Python version is 3.12, we set an alternative on `python`. However, the venv created in the lgr-django dockerfile is still using Python 3.12.