### PR TITLE
adjust-replicas: increase replicas for front end deployments

### DIFF
--- a/helm/lgr/templates/deployment.yaml
+++ b/helm/lgr/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ $.Values.app }}
     env: {{ $.Values.env }}
 spec:
-  replicas: {{ $.Values.replicaCount }}
+  replicas: {{ .replicaCount }}
   revisionHistoryLimit: {{ $.Values.historyLimit }}
   selector:
     matchLabels:

--- a/helm/values/values-prod-dc.yaml
+++ b/helm/values/values-prod-dc.yaml
@@ -4,7 +4,6 @@ region: dc
 namespace: contracted-parties
 app: lgr
 
-replicaCount: 1
 historyLimit: 3
 
 serviceAccount: sa-icannhostpathroot
@@ -38,6 +37,7 @@ microservices:
   gunicorn:
     name: gunicorn
     image: lgr-gunicorn
+    replicaCount: 2
     volume: true
     smtp: true
     uid: 30404
@@ -58,6 +58,7 @@ microservices:
   static:
     name: static
     image: lgr-static
+    replicaCount: 1
     uid: 0
     gid: 0
     web:
@@ -77,6 +78,7 @@ microservices:
   celery:
     name: celery
     image: lgr-celery
+    replicaCount: 2
     uid: 30404
     gid: 0
     volume: true
@@ -92,6 +94,7 @@ microservices:
   beat:
     name: beat
     image: lgr-celery
+    replicaCount: 1
     uid: 30404
     gid: 0
     volume: true

--- a/helm/values/values-prod-lax.yaml
+++ b/helm/values/values-prod-lax.yaml
@@ -4,7 +4,6 @@ region: lax
 namespace: contracted-parties
 app: lgr
 
-replicaCount: 1
 historyLimit: 3
 
 serviceAccount: sa-icannhostpathroot
@@ -38,6 +37,7 @@ microservices:
   gunicorn:
     name: gunicorn
     image: lgr-gunicorn
+    replicaCount: 2
     volume: true
     smtp: true
     uid: 30404
@@ -58,6 +58,7 @@ microservices:
   static:
     name: static
     image: lgr-static
+    replicaCount: 1
     uid: 0
     gid: 0
     web:
@@ -77,6 +78,7 @@ microservices:
   celery:
     name: celery
     image: lgr-celery
+    replicaCount: 2
     uid: 30404
     gid: 0
     volume: true
@@ -92,6 +94,7 @@ microservices:
   beat:
     name: beat
     image: lgr-celery
+    replicaCount: 1
     uid: 30404
     gid: 0
     volume: true

--- a/helm/values/values-qa.yaml
+++ b/helm/values/values-qa.yaml
@@ -3,7 +3,6 @@ env: qa
 namespace: contracted-parties
 app: lgr
 
-replicaCount: 1
 historyLimit: 3
 
 serviceAccount: sa-icannhostpathroot
@@ -37,6 +36,7 @@ microservices:
   gunicorn:
     name: gunicorn
     image: lgr-gunicorn
+    replicaCount: 2
     volume: true
     smtp: true
     uid: 30404
@@ -57,6 +57,7 @@ microservices:
   static:
     name: static
     image: lgr-static
+    replicaCount: 1
     uid: 0
     gid: 0
     clusterIP: 100.98.203.189
@@ -77,6 +78,7 @@ microservices:
   celery:
     name: celery
     image: lgr-celery
+    replicaCount: 2
     uid: 30404
     gid: 0
     volume: true
@@ -92,6 +94,7 @@ microservices:
   beat:
     name: beat
     image: lgr-celery
+    replicaCount: 1
     uid: 30404
     gid: 0
     volume: true


### PR DESCRIPTION
I tested this by comparing the helm template before and after the change:
```
helm template lgr-django lgr --values values/values-prod-dc.yaml > current-prod-dc.yaml
# made change
helm template lgr-django lgr --values values/values-prod-dc.yaml > new-prod-dc.yaml
```
Then I diff'ed the two yamls.

We will need to redeploy with the new helm chart.