### PR TITLE
Upgrade Django to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The main dependencies are defined in the [requirements.in](etc/requirements.in) 
 * [django-celery-results](https://github.com/celery/django-celery-results) [BSD License]
 * [django-cleanup](https://github.com/un1t/django-cleanup) [MIT License]
 * [django-redis](https://github.com/jazzband/django-redis) [BSD License]
-* [django-redis-cache](https://github.com/sebleier/django-redis-cache) [BSD License]
 * [django-widget-tweaks](https://github.com/kmike/django-widget-tweaks) [MIT License]
 * [lgr-core](https://github.com/icann/lgr-core) [BSD License]
 * [munidata](https://github.com/icann/munidata) [BSD License]

--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -1,13 +1,12 @@
 # Core stuff
 celery[redis]==5.2.3
-django<4.0
+django<4.1
 django-autocomplete-light
-django-celery-beat<2.3.0 # Drops Django 3.1
+django-celery-beat<2.6.0
 django-celery-results
-django-cleanup<6.0.0 # Drops Django 3.1
+django-cleanup<7.0.0
 django-redis
-django-redis-cache
-django-widget-tweaks<1.4.11 # Drops Django 3.1
+django-widget-tweaks<1.5.0
 vine
 
 
@@ -29,7 +28,3 @@ okta-jwt-verifier
 
 # django-celery-beat / django-cleanup / django-widget-tweaks doesn't pin correctly the requirements
 # for Django in their projects, so we have to pin them here to keep a compatible version for each.
-
-# Dependencies issues with django-redis-cache. It is not maintained anymore, and clashed with
-# celery, as it pinned redis<4. Also not supporting Django 4. It would be required to replace
-# this dependency to properly update the dependency for Django beyond 3.2.

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -37,29 +37,30 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
+cron-descriptor==2.0.6
+    # via django-celery-beat
 decorator==5.2.1
     # via retry2
-django==3.2.25
+django==4.0.10
     # via
     #   -r requirements.in
+    #   django-autocomplete-light
     #   django-celery-beat
     #   django-redis
     #   django-timezone-field
-django-autocomplete-light==3.9.4
+django-autocomplete-light==3.12.1
     # via -r requirements.in
-django-celery-beat==2.2.1
+django-celery-beat==2.5.0
     # via -r requirements.in
 django-celery-results==2.4.0
     # via -r requirements.in
-django-cleanup==5.2.0
+django-cleanup==6.0.0
     # via -r requirements.in
 django-redis==5.2.0
     # via -r requirements.in
-django-redis-cache==3.0.1
-    # via -r requirements.in
-django-timezone-field==4.2.3
+django-timezone-field==7.1
     # via django-celery-beat
-django-widget-tweaks==1.4.9
+django-widget-tweaks==1.4.12
     # via -r requirements.in
 frozenlist==1.7.0
     # via
@@ -107,25 +108,23 @@ pyjwt==2.10.1
 python-crontab==3.3.0
     # via django-celery-beat
 pytz==2025.2
-    # via
-    #   celery
-    #   django
-    #   django-timezone-field
+    # via celery
 redis==3.5.3
     # via
     #   celery
     #   django-redis
-    #   django-redis-cache
 retry2==0.9.5
     # via okta-jwt-verifier
-six==1.17.0
-    # via django-autocomplete-light
 sqlparse==0.5.3
     # via django
 typing-extensions==4.15.0
-    # via aiosignal
+    # via
+    #   aiosignal
+    #   cron-descriptor
 tzdata==2025.2
-    # via kombu
+    # via
+    #   django-celery-beat
+    #   kombu
 vine==5.1.0
     # via
     #   -r requirements.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "django-celery-results",
     "django-cleanup",
     "django-redis",
-    "django-redis-cache",
     "django-widget-tweaks",
     "lgr-core",
     "munidata",

--- a/src/lgr_advanced/lgr_editor/forms/codepoint.py
+++ b/src/lgr_advanced/lgr_editor/forms/codepoint.py
@@ -1,12 +1,14 @@
-# -*- coding: utf-8 -*-
 from urllib.parse import quote_plus
 
 from django import forms
 from django.forms import HiddenInput
 from django.forms.formsets import formset_factory
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
-from .utils import BaseDisableableFormSet, ReadOnlyTextInput, MultipleChoiceFieldNoValidation
+from lgr_advanced.lgr_editor.forms.utils import (
+    BaseDisableableFormSet,
+    MultipleChoiceFieldNoValidation,
+    ReadOnlyTextInput)
 
 
 class CodepointForm(forms.Form):

--- a/src/lgr_advanced/lgr_editor/forms/codepoints.py
+++ b/src/lgr_advanced/lgr_editor/forms/codepoints.py
@@ -1,13 +1,11 @@
-# -*- coding: utf-8 -*-
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
+from lgr.tools.utils import parse_codepoint_input, parse_single_cp_input
 
-from lgr.tools.utils import parse_single_cp_input, parse_codepoint_input
-from lgr_advanced.lgr_editor.forms.fields import (ValidatingRepertoire,
-                                                  FILE_FIELD_ENCODING_HELP)
+from lgr_advanced.lgr_editor.forms.fields import FILE_FIELD_ENCODING_HELP, ValidatingRepertoire
+from lgr_advanced.lgr_editor.forms.utils import MultipleChoiceFieldNoValidation
 from lgr_advanced.widgets import DataSelectWidget
-from .utils import MultipleChoiceFieldNoValidation
 
 
 class CodepointField(forms.CharField):

--- a/src/lgr_advanced/lgr_editor/forms/fields.py
+++ b/src/lgr_advanced/lgr_editor/forms/fields.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import hashlib
 import logging
 from itertools import chain
@@ -6,9 +5,9 @@ from typing import List
 
 from django.core.cache import cache
 from django.utils.encoding import force_bytes
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
-from lgr_models.models.lgr import LgrBaseModel, RzLgr, MSR, IDNARepertoire
+from lgr_models.models.lgr import IDNARepertoire, LgrBaseModel, MSR, RzLgr
 from lgr_utils.utils import LGR_CACHE_KEY_PREFIX
 
 FILE_FIELD_ENCODING_HELP = _('File must be encoded in UTF-8 and using 0x0A line ending.')

--- a/src/lgr_advanced/lgr_editor/forms/importer.py
+++ b/src/lgr_advanced/lgr_editor/forms/importer.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core import validators
 from django.forms.utils import ErrorList
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_advanced.lgr_editor.forms.fields import FILE_FIELD_ENCODING_HELP, ValidatingRepertoire
 from lgr_utils.forms import MultipleFileField

--- a/src/lgr_advanced/lgr_editor/forms/metadata.py
+++ b/src/lgr_advanced/lgr_editor/forms/metadata.py
@@ -1,15 +1,14 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 
 from dal import autocomplete
 from django import forms
 from django.conf import settings
 from django.forms.formsets import formset_factory
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
+from lgr_advanced.lgr_editor.forms.fields import ValidatingRepertoire
+from lgr_advanced.lgr_editor.forms.utils import BaseDisableableFormSet
 from lgr_web.utils import IANA_LANG_REGISTRY
-from .fields import ValidatingRepertoire
-from .utils import BaseDisableableFormSet
 
 
 def DateInputPlaceHolder(placeholder=''):

--- a/src/lgr_advanced/lgr_editor/forms/references.py
+++ b/src/lgr_advanced/lgr_editor/forms/references.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 import re
 
 from django import forms
 from django.forms.formsets import formset_factory
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from lgr.metadata import ReferenceManager
-from .utils import BaseDisableableFormSet, ReadOnlyTextInput
+
+from lgr_advanced.lgr_editor.forms.utils import BaseDisableableFormSet, ReadOnlyTextInput
 
 
 class ReferenceForm(forms.Form):

--- a/src/lgr_advanced/lgr_editor/views/codepoints/codepoint.py
+++ b/src/lgr_advanced/lgr_editor/views/codepoints/codepoint.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-codepoint - 
-"""
 import json
 import logging
 from ast import literal_eval
@@ -12,22 +7,20 @@ from django.contrib import messages
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 from django.views.generic.base import TemplateView, View
-
 from lgr.char import RangeChar
 from lgr.exceptions import LGRException, NotInLGR
 from lgr.utils import format_cp, is_idna_valid_cp_or_sequence
-from lgr_advanced.lgr_editor.forms import (AddVariantForm,
-                                           CodepointForm,
-                                           CodepointVariantFormSet)
-from lgr_advanced.lgr_editor.utils import slug_to_cp, render_char, var_to_slug, render_age, slug_to_var
+
+from lgr_advanced.lgr_editor.forms import AddVariantForm, CodepointForm, CodepointVariantFormSet
+from lgr_advanced.lgr_editor.utils import render_age, render_char, slug_to_cp, slug_to_var, var_to_slug
 from lgr_advanced.lgr_editor.views.codepoints.mixins import CodePointMixin
-from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin, LGREditMixin
+from lgr_advanced.lgr_editor.views.mixins import LGREditMixin, LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_utils import unidb
-from lgr_utils.cp import render_name, cp_to_slug
+from lgr_utils.cp import cp_to_slug, render_name
 
 logger = logging.getLogger(__name__)
 

--- a/src/lgr_advanced/lgr_editor/views/codepoints/importer.py
+++ b/src/lgr_advanced/lgr_editor/views/codepoints/importer.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-importer.py -
-"""
 import logging
 from io import StringIO
 
@@ -10,20 +5,18 @@ from django.contrib import messages
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.html import format_html_join
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
-
 from lgr.core import LGR
 from lgr.exceptions import LGRException
 from lgr.parser.heuristic_parser import HeuristicParser
-from lgr.parser.line_parser import LineParser
-from lgr.parser.rfc3743_parser import RFC3743Parser
-from lgr.parser.rfc4290_parser import RFC4290Parser
+
 from lgr_advanced.api import copy_characters
-from lgr_advanced.lgr_editor.forms import (AddMultiCodepointsForm,
-                                           AddRangeForm,
-                                           ImportCodepointsFromFileForm,
-                                           AddCodepointFromScriptForm)
+from lgr_advanced.lgr_editor.forms import (
+    AddCodepointFromScriptForm,
+    AddMultiCodepointsForm,
+    AddRangeForm,
+    ImportCodepointsFromFileForm)
 from lgr_advanced.lgr_editor.utils import slug_to_cp
 from lgr_advanced.lgr_editor.views.mixins import LGREditMixin
 from lgr_advanced.models import LgrModel, TmpLgrModel

--- a/src/lgr_advanced/lgr_editor/views/codepoints/list.py
+++ b/src/lgr_advanced/lgr_editor/views/codepoints/list.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-list.py - 
-"""
 import logging
 from io import StringIO
 
@@ -10,22 +5,21 @@ from django.contrib import messages
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
-from django.views.generic import TemplateView, FormView
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import FormView, TemplateView
 from django.views.generic.base import View
-
 from lgr.char import RangeChar
-from lgr.exceptions import LGRException, LGRFormatException, CharInvalidContextRule
+from lgr.exceptions import CharInvalidContextRule, LGRException, LGRFormatException
 from lgr.utils import format_cp, is_idna_valid_cp_or_sequence
 from lgr.validate import check_symmetry, check_transitivity
-from lgr_advanced.lgr_editor.forms import (AddCodepointForm,
-                                           EditCodepointsForm)
-from lgr_advanced.lgr_editor.utils import slug_to_cp, render_char
+
+from lgr_advanced.lgr_editor.forms import AddCodepointForm, EditCodepointsForm
+from lgr_advanced.lgr_editor.utils import render_char, slug_to_cp
 from lgr_advanced.lgr_editor.views.codepoints.mixins import CodePointMixin
-from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin, LGREditMixin
+from lgr_advanced.lgr_editor.views.mixins import LGREditMixin, LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_utils import unidb
-from lgr_utils.cp import render_name, cp_to_slug
+from lgr_utils.cp import cp_to_slug, render_name
 
 logger = logging.getLogger(__name__)
 

--- a/src/lgr_advanced/lgr_editor/views/create.py
+++ b/src/lgr_advanced/lgr_editor/views/create.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-create - 
-"""
 import logging
 import os
 import re
@@ -14,17 +9,17 @@ from django.contrib import messages
 from django.core.exceptions import SuspiciousOperation
 from django.core.files import File
 from django.db import transaction
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import FormView
-
 from lgr.exceptions import LGRException
+
 from lgr_advanced.lgr_editor.forms import CreateLGRForm, ImportLGRForm
 from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
-from lgr_advanced.models import LgrModel, SetLgrModel, LgrSetInfo
+from lgr_advanced.models import LgrModel, LgrSetInfo, SetLgrModel
 from lgr_advanced.views import LGRViewMixin
 from lgr_models.models.lgr import LgrBaseModel
 

--- a/src/lgr_advanced/lgr_editor/views/metadata.py
+++ b/src/lgr_advanced/lgr_editor/views/metadata.py
@@ -1,18 +1,13 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-metadata - 
-"""
 import logging
 
 from django.contrib import messages
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
-
 from lgr.exceptions import LGRException
-from lgr.metadata import Scope, Metadata, Version, Description
-from lgr_advanced.lgr_editor.forms import MetadataForm, LanguageFormSet
+from lgr.metadata import Description, Metadata, Scope, Version
+
+from lgr_advanced.lgr_editor.forms import LanguageFormSet, MetadataForm
 from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_advanced.models import LgrModel

--- a/src/lgr_advanced/lgr_editor/views/mixins.py
+++ b/src/lgr_advanced/lgr_editor/views/mixins.py
@@ -1,15 +1,10 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-mixins - 
-"""
 import logging
 import typing
 
 from django.http import HttpResponseBadRequest
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from lgr.core import LGR
+
 from lgr_advanced.models import LgrModel, SetLgrModel
 from lgr_advanced.views import LGRViewMixin
 from lgr_models.models.lgr import LgrBaseModel

--- a/src/lgr_advanced/lgr_editor/views/reference.py
+++ b/src/lgr_advanced/lgr_editor/views/reference.py
@@ -1,21 +1,16 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-reference - 
-"""
 import logging
 
 from django.contrib import messages
 from django.http import Http404, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
-from django.views.generic import TemplateView, FormView
-
+from django.views.generic import FormView, TemplateView
 from lgr.exceptions import LGRException
+
 from lgr_advanced.lgr_editor.forms import ReferenceForm, ReferenceFormSet
-from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin, LGREditMixin
+from lgr_advanced.lgr_editor.views.mixins import LGREditMixin, LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 
 logger = logging.getLogger('reference')

--- a/src/lgr_advanced/lgr_editor/views/rule.py
+++ b/src/lgr_advanced/lgr_editor/views/rule.py
@@ -1,20 +1,15 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-rule -
-"""
 import logging
 
 from django.http import JsonResponse
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import TemplateView
-from lxml.etree import XMLSyntaxError
-
 from lgr.exceptions import LGRException
 from lgr.parser.xml_parser import LGR_NS
-from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin, LGREditMixin
+from lxml.etree import XMLSyntaxError
+
+from lgr_advanced.lgr_editor.views.mixins import LGREditMixin, LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_advanced.models import LgrModel
 
@@ -111,7 +106,7 @@ class ListRuleView(LGRHandlingBaseMixin, TemplateView):
 def _json_response(success, error_msg=None):
     rv = {'success': success}
     if error_msg:
-        rv['message'] = force_text(error_msg)
+        rv['message'] = force_str(error_msg)
     return JsonResponse(rv, charset='UTF-8')
 
 

--- a/src/lgr_advanced/lgr_editor/views/set.py
+++ b/src/lgr_advanced/lgr_editor/views/set.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 import logging
 
-from django.http import (HttpResponseBadRequest)
-from django.utils.translation import ugettext_lazy as _
+from django.http import HttpResponseBadRequest
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
 from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin

--- a/src/lgr_advanced/lgr_editor/views/tag.py
+++ b/src/lgr_advanced/lgr_editor/views/tag.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-tag - 
-"""
 import logging
 from itertools import islice
 
@@ -10,13 +5,13 @@ from django.contrib import messages
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import TemplateView
-
 from lgr.exceptions import LGRException
+
 from lgr_advanced.lgr_editor.utils import render_cp_or_sequence
-from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin, LGREditMixin
+from lgr_advanced.lgr_editor.views.mixins import LGREditMixin, LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_utils.cp import cp_to_slug
 

--- a/src/lgr_advanced/lgr_editor/views/validate.py
+++ b/src/lgr_advanced/lgr_editor/views/validate.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 
 from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin

--- a/src/lgr_advanced/lgr_exceptions.py
+++ b/src/lgr_advanced/lgr_exceptions.py
@@ -1,14 +1,12 @@
-# -*- coding: utf-8 -*-
 """
 lgr_exceptions.py - Map LGR exception to user terms.
 """
-from django.utils.translation import ugettext
-from django.utils.translation import ugettext_lazy as _
-
 import lgr.exceptions
+from django.utils.translation import gettext, gettext_lazy as _
 from lgr.utils import format_cp
 from picu.exceptions import IDNAException
-from lgr_models.exceptions import LGRValidationException, LGRUnsupportedUnicodeVersionException
+
+from lgr_models.exceptions import LGRUnsupportedUnicodeVersionException, LGRValidationException
 
 
 def lgr_exception_to_text(exception):
@@ -140,66 +138,71 @@ def lgr_exception_to_text(exception):
         messages = []
         for error in exception.error_labels:
             if error == 'UIDNA_ERROR_EMPTY_LABEL':
-                messages.append(ugettext('Label is empty'))
+                messages.append(gettext('Label is empty'))
             elif error == 'UIDNA_ERROR_LABEL_TOO_LONG':
-                messages.append(ugettext('%(label)s is invalid due to its length being longer than 63 bytes.') % {
-                    'label': exception.obj
-                })
-            # elif error == 'UIDNA_ERROR_DOMAIN_NAME_TOO_LONG':
+                messages.append(gettext(
+                    '%(label)s is invalid due to its length being longer than 63 bytes.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_LEADING_HYPHEN':
-                messages.append(ugettext('%(label)s is invalid due to hyphen restrictions in the RFC5891 as it starts '
-                                         'with a hyphen-minus.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to hyphen restrictions in the RFC5891 as it starts with a '
+                    'hyphen-minus.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_TRAILING_HYPHEN':
-                messages.append(ugettext('%(label)s is invalid due to hyphen restrictions in the RFC5891 as it ends '
-                                         'with a hyphen-minus.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to hyphen restrictions in the RFC5891 as it ends with a hyphen-minus.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_HYPHEN_3_4':
-                messages.append(ugettext('%(label)s is invalid due to hyphen restrictions in the RFC5891 as it '
-                                         'contains hyphen-minus in the third and fourth positions.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to hyphen restrictions in the RFC5891 as it contains hyphen-minus in '
+                    'the third and fourth positions.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_LEADING_COMBINING_MARK':
-                messages.append(ugettext('%(label)s is invalid due to leading combining marks restriction in the '
-                                         'RFC5891.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to leading combining marks restriction in the RFC5891.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_DISALLOWED':
-                messages.append(ugettext('%(label)s is invalid as it contains disallowed characters.' % {
-                    'label': exception.obj
-                }))
+                messages.append(gettext(
+                    '%(label)s is invalid as it contains disallowed characters.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_PUNYCODE':
-                messages.append(ugettext('%(label)s is invalid as it starts with ‘xn--’ but does not contain valid '
-                                         'Punycode.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid as it starts with ‘xn--’ but does not contain valid Punycode.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_LABEL_HAS_DOT':
-                messages.append(ugettext('%(label)s is invalid as it contains full stop (dot).' % {
-                    'label': exception.obj
-                }))
+                messages.append(gettext(
+                    '%(label)s is invalid as it contains full stop (dot).' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_INVALID_ACE_LABEL':
-                messages.append(ugettext('%(label)s is invalid due to invalid Punycode.' % {'label': exception.obj}))
+                messages.append(gettext('%(label)s is invalid due to invalid Punycode.' % {'label': exception.obj}))
             elif error == 'UIDNA_ERROR_BIDI':
-                messages.append(ugettext('%(label)s is invalid due to  the Bidi rule in the RFC5893.' % {
-                    'label': exception.obj
-                }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to  the Bidi rule in the RFC5893.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_CONTEXTJ':
-                messages.append(ugettext('%(label)s is invalid due to the IDNA contextual rule for Zero Width '
-                                         'Joiner.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to the IDNA contextual rule for Zero Width Joiner.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_CONTEXTO_PUNCTUATION':
-                messages.append(ugettext('%(label)s is invalid due to the IDNA contextual rule for punctuation in '
-                                         'the RFC5892.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to the IDNA contextual rule for punctuation in the RFC5892.' % {
+                        'label': exception.obj
+                    }))
             elif error == 'UIDNA_ERROR_CONTEXTO_DIGITS':
-                messages.append(ugettext('%(label)s is invalid due to the IDNA contextual rule for digits in the '
-                                         'RFC5892.' % {
-                                             'label': exception.obj
-                                         }))
+                messages.append(gettext(
+                    '%(label)s is invalid due to the IDNA contextual rule for digits in the RFC5892.' % {
+                        'label': exception.obj
+                    }))
             else:
                 messages.append(exception)
             message = '\n'.join(messages)

--- a/src/lgr_advanced/lgr_tools/forms.py
+++ b/src/lgr_advanced/lgr_tools/forms.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 from django import forms
 from django.core.validators import FileExtensionValidator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_advanced.lgr_editor.forms.fields import LABEL_FILE_HELP
 from lgr_advanced.models import LgrModel

--- a/src/lgr_advanced/lgr_tools/middleware.py
+++ b/src/lgr_advanced/lgr_tools/middleware.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-# Author: Viagénie
 """
 middleware - Implement some middlewares used by the whole app.
 """
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import redirect
+from django.utils.translation import gettext_lazy as _
 
 
 class UnicodeDecodeErrorMiddleWare:

--- a/src/lgr_advanced/lgr_tools/views.py
+++ b/src/lgr_advanced/lgr_tools/views.py
@@ -1,29 +1,30 @@
-# -*- coding: utf-8 -*-
 from django.conf import settings
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
-
 from lgr.tools.utils import download_file
-from lgr_advanced.lgr_tools.api import lgr_intersect_union, lgr_comp_diff, lgr_harmonization, LGRCompInvalidException
-from lgr_advanced.lgr_tools.forms import (LGRCompareSelector,
-                                          LGRDiffSelector,
-                                          LGRCollisionSelector,
-                                          LGRAnnotateSelector,
-                                          LGRHarmonizeSelector,
-                                          LGRComputeVariantsSelector)
+
+from lgr_advanced.api import LabelInfo
+from lgr_advanced.lgr_tools.api import LGRCompInvalidException, lgr_comp_diff, lgr_harmonization, lgr_intersect_union
+from lgr_advanced.lgr_tools.forms import (
+    LGRAnnotateSelector,
+    LGRCollisionSelector,
+    LGRCompareSelector,
+    LGRComputeVariantsSelector,
+    LGRDiffSelector,
+    LGRHarmonizeSelector)
+from lgr_advanced.lgr_tools.tasks import (
+    annotate_task,
+    collision_task,
+    diff_task,
+    lgr_set_annotate_task,
+    validate_labels_task)
+from lgr_advanced.models import LgrModel
+from lgr_advanced.views import LGRViewMixin
 from lgr_models.models.lgr import LgrBaseModel, RzLgr
 from lgr_tasks.models import LgrTaskModel
 from lgr_utils.cp import cp_to_slug
-from .tasks import (diff_task,
-                    collision_task,
-                    annotate_task,
-                    lgr_set_annotate_task,
-                    validate_labels_task)
-from ..api import LabelInfo
-from ..models import LgrModel, SetLgrModel
-from ..views import LGRViewMixin
 
 
 class LGRToolBaseView(LGRViewMixin, FormView):

--- a/src/lgr_advanced/lgr_validator/api.py
+++ b/src/lgr_advanced/lgr_validator/api.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 import codecs
 import csv
 
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from lgr.core import LGR
 from lgr.tools.diff_collisions import get_collisions
 from lgr.utils import cp_to_ulabel

--- a/src/lgr_advanced/lgr_validator/forms.py
+++ b/src/lgr_advanced/lgr_validator/forms.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from lgr.tools.utils import parse_label_input
+
 from lgr_advanced.lgr_editor.forms.fields import LABEL_INPUT_HELP
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 

--- a/src/lgr_advanced/lgr_validator/views.py
+++ b/src/lgr_advanced/lgr_validator/views.py
@@ -1,21 +1,20 @@
-# -*- coding: utf-8 -*-
 from django.contrib import messages
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
-from django.utils.translation import ugettext_lazy as _
-
 from lgr.exceptions import LGRException
+
+from lgr_advanced.api import LabelInfo
+from lgr_advanced.lgr_editor.views.mixins import LGRHandlingBaseMixin
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
-from lgr_advanced.lgr_tools.tasks import validate_label_task, lgr_set_validate_label_task
+from lgr_advanced.lgr_tools.tasks import lgr_set_validate_label_task, validate_label_task
+from lgr_advanced.lgr_validator.api import evaluate_label, lgr_set_evaluate_label, validation_results_to_csv
+from lgr_advanced.lgr_validator.forms import ValidateLabelForm
+from lgr_advanced.models import LgrModel
+from lgr_models.models.lgr import LgrBaseModel
 from lgr_tasks.models import LgrTaskModel
 from lgr_utils.unidb import get_db_by_version
-from lgr_models.models.lgr import LgrBaseModel
-from .api import validation_results_to_csv, lgr_set_evaluate_label, evaluate_label
-from .forms import ValidateLabelForm
-from ..api import LabelInfo
-from ..lgr_editor.views.mixins import LGRHandlingBaseMixin
-from ..models import LgrModel
 
 
 class NeedAsyncProcess(Exception):

--- a/src/lgr_auth/models.py
+++ b/src/lgr_auth/models.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from enum import Enum
 
-from django.contrib.auth.base_user import BaseUserManager, AbstractBaseUser
+from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_auth.validators import ua_validate_email
 

--- a/src/lgr_auth/views.py
+++ b/src/lgr_auth/views.py
@@ -1,8 +1,3 @@
-#! /bin/env python
-# -*- coding: utf-8 -*-
-"""
-views.py
-"""
 import logging
 from enum import Enum
 
@@ -10,15 +5,14 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.views import LogoutView, LoginView
+from django.contrib.auth.views import LoginView, LogoutView
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import redirect, resolve_url
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import UpdateView
-from django.views.generic import View, TemplateView
+from django.views.generic import TemplateView, UpdateView, View
 
 from lgr_auth.forms import UserForm
 from lgr_auth.models import LgrUser

--- a/src/lgr_basic/forms.py
+++ b/src/lgr_basic/forms.py
@@ -1,13 +1,11 @@
-# -*- coding: utf-8 -*-
 from dal import autocomplete
 from django import forms
 from django.conf import settings
 from django.core.validators import FileExtensionValidator
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from lgr.tools.utils import parse_label_input
+
 from lgr_advanced.lgr_editor.forms.fields import LABEL_FILE_HELP, LABEL_INPUT_HELP
-from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_models.models.lgr import LgrBaseModel
 from lgr_utils.unidb import get_db_by_version
 

--- a/src/lgr_basic/views.py
+++ b/src/lgr_basic/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from io import StringIO
 
 from django.conf import settings
@@ -7,21 +6,21 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import FormView
-
 from lgr.exceptions import LGRException
 from lgr.tools.utils import download_file, read_labels
 from lgr.utils import cp_to_ulabel
-from lgr_advanced.api import LabelInfo, LGRToolReportStorage
+
+from lgr_advanced.api import LGRToolReportStorage, LabelInfo
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_advanced.lgr_tools.tasks import annotate_task, basic_collision_task
 from lgr_advanced.lgr_validator.views import NeedAsyncProcess, evaluate_label_from_view
-from lgr_models.models.lgr import RzLgr, LgrBaseModel
+from lgr_basic.forms import ValidateLabelSimpleForm
+from lgr_models.models.lgr import LgrBaseModel, RzLgr
 from lgr_tasks.models import LgrTaskModel
 from lgr_tasks.tasks import _index_cache_key
 from lgr_utils.views import RefLgrAutocomplete
-from .forms import ValidateLabelSimpleForm
 
 
 class BasicModeView(LoginRequiredMixin, FormView):

--- a/src/lgr_idn_table_review/icann_tools/views.py
+++ b/src/lgr_idn_table_review/icann_tools/views.py
@@ -1,20 +1,17 @@
-# -*- coding: utf-8 -*-
-import uuid
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import TemplateView
 
 from lgr_idn_table_review.icann_tools.api import LGRIcannReportStorage
-from lgr_tasks.models import LgrTaskModel
-from lgr_idn_table_review.icann_tools.tasks.review import idn_table_review_task
 from lgr_idn_table_review.icann_tools.tasks.compliance import idn_table_compliance_task
+from lgr_idn_table_review.icann_tools.tasks.review import idn_table_review_task
+from lgr_tasks.models import LgrTaskModel
 
 
 class BaseIcannView(LoginRequiredMixin, UserPassesTestMixin):

--- a/src/lgr_idn_table_review/idn_tool/forms.py
+++ b/src/lgr_idn_table_review/idn_tool/forms.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from dal import autocomplete
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import FileField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_advanced.lgr_editor.forms import FILE_FIELD_ENCODING_HELP
 from lgr_utils.forms import MultipleFileField

--- a/src/lgr_idn_table_review/idn_tool/views.py
+++ b/src/lgr_idn_table_review/idn_tool/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -6,14 +5,14 @@ from django.core.exceptions import SuspiciousOperation
 from django.core.files import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.shortcuts import redirect
-from django.urls import reverse_lazy, reverse
-from django.utils.translation import ugettext_lazy as _, ngettext
+from django.urls import reverse, reverse_lazy
+from django.utils.translation import gettext_lazy as _, ngettext
 from django.views import View
 from django.views.generic import FormView, TemplateView
 
 from lgr_advanced.lgr_editor.views.create import RE_SAFE_FILENAME
 from lgr_idn_table_review.idn_tool.api import LGRIdnReviewApi
-from lgr_idn_table_review.idn_tool.forms import LGRIdnTableReviewForm, IdnTableReviewSelectReferenceForm
+from lgr_idn_table_review.idn_tool.forms import IdnTableReviewSelectReferenceForm, LGRIdnTableReviewForm
 from lgr_idn_table_review.idn_tool.tasks import idn_table_review_task
 from lgr_tasks.models import LgrTaskModel
 from lgr_utils.views import safe_next_redirect_url

--- a/src/lgr_manage/forms.py
+++ b/src/lgr_manage/forms.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from pathlib import Path
 
 from dal import autocomplete
 from django import forms
 from django.db import transaction
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_advanced.lgr_editor.forms import FILE_FIELD_ENCODING_HELP
 from lgr_models.models.lgr import IDNARepertoire, MSR, RefLgr, RefLgrMember, RzLgr, RzLgrMember

--- a/src/lgr_manage/views/ajax_mixin.py
+++ b/src/lgr_manage/views/ajax_mixin.py
@@ -37,7 +37,10 @@ class AjaxFormViewMixin(BaseAdminMixin):
 
     def form_invalid(self, form):
         response = super(AjaxFormViewMixin, self).form_invalid(form)
-        if self.request.is_ajax():
+        if self._is_ajax(self.request):
             return JsonResponse(form.errors, status=400)
         else:
             return response
+
+    def _is_ajax(self, request):
+        return request.META.get('HTTP_X_REQUESTED_WITH', '') == 'XMLHttpRequest'

--- a/src/lgr_manage/views/ajax_mixin.py
+++ b/src/lgr_manage/views/ajax_mixin.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.http import JsonResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_manage.views.common import BaseAdminMixin
 

--- a/src/lgr_manage/views/common.py
+++ b/src/lgr_manage/views/common.py
@@ -58,9 +58,8 @@ class BaseCreateInitActiveMixin(BaseAdminMixin):
 
 
 class BaseDeleteModelInitActiveMixin(BaseAdminMixin, DeleteView):
-
-    def delete(self, request, *args, **kwargs):
-        response = super().delete(request, *args, **kwargs)
+    def form_valid(self, form):
+        response = super().form_valid(form)
         if self.object.active:
             initial_active(self.model, set_active=True)
         return response

--- a/src/lgr_manage/views/idna.py
+++ b/src/lgr_manage/views/idna.py
@@ -1,13 +1,16 @@
-# -*- coding: utf-8 -*-
 from django import views
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_manage.forms import IDNACreateForm, IDNAIsActiveForm
 from lgr_manage.views.ajax_mixin import AjaxFormViewMixin
-from lgr_manage.views.common import BaseListAdminView, BaseAdminMixin, BaseCreateInitActiveMixin, \
-    BaseDeleteModelInitActiveMixin, initial_active
+from lgr_manage.views.common import (
+    BaseAdminMixin,
+    BaseCreateInitActiveMixin,
+    BaseDeleteModelInitActiveMixin,
+    BaseListAdminView,
+    initial_active)
 from lgr_models.models.lgr import IDNARepertoire
 
 

--- a/src/lgr_manage/views/msr.py
+++ b/src/lgr_manage/views/msr.py
@@ -1,13 +1,16 @@
-# -*- coding: utf-8 -*-
 from django import views
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_manage.forms import MSRCreateForm, MSRIsActiveForm
 from lgr_manage.views.ajax_mixin import AjaxFormViewMixin
-from lgr_manage.views.common import BaseListAdminView, BaseAdminMixin, BaseCreateInitActiveMixin, \
-    BaseDeleteModelInitActiveMixin, initial_active
+from lgr_manage.views.common import (
+    BaseAdminMixin,
+    BaseCreateInitActiveMixin,
+    BaseDeleteModelInitActiveMixin,
+    BaseListAdminView,
+    initial_active)
 from lgr_models.models.lgr import MSR
 
 

--- a/src/lgr_manage/views/reference_lgr.py
+++ b/src/lgr_manage/views/reference_lgr.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
 from django import views
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
-from lgr_manage.forms import RefLgrCreateForm, RefLgrMemberUpdateForm, RefLgrIsActiveForm
+from lgr_manage.forms import RefLgrCreateForm, RefLgrIsActiveForm, RefLgrMemberUpdateForm
 from lgr_manage.views.ajax_mixin import AjaxFormViewMixin
-from lgr_manage.views.common import (BaseListAdminView,
-                                     BaseAdminMixin,
-                                     BaseDeleteModelInitActiveMixin,
-                                     BaseCreateInitActiveMixin,
-                                     initial_active)
+from lgr_manage.views.common import (
+    BaseAdminMixin,
+    BaseCreateInitActiveMixin,
+    BaseDeleteModelInitActiveMixin,
+    BaseListAdminView,
+    initial_active)
 from lgr_models.models.lgr import RefLgr, RefLgrMember
 
 

--- a/src/lgr_manage/views/rz_lgr.py
+++ b/src/lgr_manage/views/rz_lgr.py
@@ -1,13 +1,16 @@
-# -*- coding: utf-8 -*-
 from django import views
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_manage.forms import RzLgrCreateForm, RzLgrIsActiveForm
 from lgr_manage.views.ajax_mixin import AjaxFormViewMixin
-from lgr_manage.views.common import BaseListAdminView, BaseAdminMixin, BaseCreateInitActiveMixin, \
-    BaseDeleteModelInitActiveMixin, initial_active
+from lgr_manage.views.common import (
+    BaseAdminMixin,
+    BaseCreateInitActiveMixin,
+    BaseDeleteModelInitActiveMixin,
+    BaseListAdminView,
+    initial_active)
 from lgr_models.models.lgr import RzLgr
 
 

--- a/src/lgr_manage/views/settings.py
+++ b/src/lgr_manage/views/settings.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from datetime import timedelta
 
 from django.conf import settings
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import RedirectView, UpdateView
 
 from lgr_manage.api import LGRAdminReportStorage

--- a/src/lgr_manage/views/users.py
+++ b/src/lgr_manage/views/users.py
@@ -1,17 +1,15 @@
-# -*- coding: utf-8 -*-
 from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseBadRequest
 from django.urls import reverse_lazy
-from django.utils.http import url_has_allowed_host_and_scheme
-from django.utils.translation import ugettext_lazy as _
-from django.views.generic import View, RedirectView, CreateView, DeleteView
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import CreateView, DeleteView, RedirectView, View
 from django.views.generic.detail import SingleObjectMixin
 
 from lgr_auth.forms import UserForm
-from lgr_auth.models import LgrUser, LgrRole
+from lgr_auth.models import LgrRole, LgrUser
 from lgr_auth.views import LgrUserUpdateView
-from lgr_manage.views.common import BaseListAdminView, BaseAdminMixin
+from lgr_manage.views.common import BaseAdminMixin, BaseListAdminView
 from lgr_utils.views import safe_next_redirect_url
 
 

--- a/src/lgr_models/templatetags/report.py
+++ b/src/lgr_models/templatetags/report.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime
 
 from django import template
 from django.template.defaultfilters import pluralize
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from lgr_models.models.report import LGRReport
 from lgr_web.config import get_lgr_settings

--- a/src/lgr_renderer/api.py
+++ b/src/lgr_renderer/api.py
@@ -13,7 +13,7 @@ from itertools import islice
 from django.core.files import File
 from django.template.loader import render_to_string
 from django.utils.html import format_html, format_html_join, mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from lgr.classes import TAG_CLASSNAME_PREFIX
 from lgr.exceptions import NotInLGR
 from lgr.matcher import AnchorMatcher

--- a/src/lgr_session/views.py
+++ b/src/lgr_session/views.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 from enum import Enum
 
 from django.contrib import messages
-from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
-from django.http import Http404, FileResponse
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.http import FileResponse, Http404
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import View
 
 from lgr_session.api import LGRReportStorage

--- a/src/lgr_tasks/views.py
+++ b/src/lgr_tasks/views.py
@@ -4,7 +4,7 @@ from celery.states import FAILURE, PENDING, RETRY, REVOKED, SUCCESS
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import TemplateView
 from django.views.generic.detail import SingleObjectMixin

--- a/src/lgr_web/forms.py
+++ b/src/lgr_web/forms.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from django import forms
 from django.conf import settings
 from django.core.validators import FileExtensionValidator
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
 from lgr.tools.utils import parse_label_input
+
 from lgr_advanced.lgr_editor.forms.fields import LABEL_FILE_HELP, LABEL_INPUT_HELP
 from lgr_utils import unidb
 

--- a/src/lgr_web/settings/default.py
+++ b/src/lgr_web/settings/default.py
@@ -258,7 +258,7 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 # https://docs.djangoproject.com/fr/1.8/topics/cache/
 CACHES = {
     'default': {
-        'BACKEND': 'redis_cache.RedisCache',
+        'BACKEND': 'django_redis.cache.RedisCache',
         # DB 0 is used for Celery broker
         'LOCATION': 'redis://localhost:6379/1',
     }

--- a/src/lgr_web/settings/default.py
+++ b/src/lgr_web/settings/default.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from kombu import Queue
 
 

--- a/src/lgr_web/views.py
+++ b/src/lgr_web/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import codecs
 import csv
 import pathlib
@@ -9,15 +8,15 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
-from django.utils.translation import ugettext_lazy as _
-from django.views.generic import TemplateView, FormView
-
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import FormView, TemplateView
 from lgr.tools.utils import read_labels
-from lgr.utils import format_cp, cp_to_ulabel, is_idna_valid_cp_or_sequence
+from lgr.utils import cp_to_ulabel, format_cp, is_idna_valid_cp_or_sequence
+
 from lgr_advanced.api import LabelInfo
 from lgr_advanced.lgr_exceptions import lgr_exception_to_text
 from lgr_utils import unidb
-from lgr_web.forms import LabelFormsForm, LabelFileFormsForm
+from lgr_web.forms import LabelFileFormsForm, LabelFormsForm
 from lgr_web.utils import IANA_LANG_REGISTRY
 
 


### PR DESCRIPTION
References:
[Release notes of Django](https://docs.djangoproject.com/en/dev/releases/4.0/)


The highlights:
- Update Django and other adjacent dependencies
- `ugettext()` and `ugettext_lazy()` have been replaced by `gettext()` and `gettext_lazy()` respectively
- ` force_text()` has been replaced by `force_str()`
- `django-redis-cache` has been removed from the dependencies
  - `django-redis` was already being used, since it is supporting `Sentinel`
- Create method in `ajax_mixin()` to address the deprecation of `request.is_ajax()`
- Replace `delete()` method with `form_valid()` in a mixin for a `DeleteView`