### PR TITLE
Upgrade Django to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ The main dependencies are defined in the [requirements.in](etc/requirements.in) 
 * [natsort](https://pypi.python.org/pypi/natsort) [MIT License]
 * [okta-jwt-verifier](https://pypi.org/project/okta-jwt-verifier/) [Apache Software License]
 * [picu](https://pypi.python.org/pypi/picu) [MIT/X License]
-* [vine](https://pypi.org/project/vine/) [BSD License]
 
 
 #### Testing Dependencies

--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -1,13 +1,15 @@
-# Core stuff
-celery[redis]==5.2.3
-django<4.1
+# Django
+django<4.2
 django-autocomplete-light
-django-celery-beat<2.6.0
-django-celery-results
 django-cleanup<7.0.0
 django-redis
-django-widget-tweaks<1.5.0
-vine
+django-widget-tweaks
+
+
+# Celery
+celery[redis]
+django-celery-beat<2.6.0
+django-celery-results
 
 
 # LGR/Unicode modules
@@ -22,9 +24,3 @@ natsort
 
 # ICANN Login
 okta-jwt-verifier
-
-
-# Notes
-
-# django-celery-beat / django-cleanup / django-widget-tweaks doesn't pin correctly the requirements
-# for Django in their projects, so we have to pin them here to keep a compatible version for each.

--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -1,14 +1,14 @@
 # Django
-django<4.2
+django<5
 django-autocomplete-light
-django-cleanup<7.0.0
+django-cleanup
 django-redis
 django-widget-tweaks
 
 
 # Celery
 celery[redis]
-django-celery-beat<2.6.0
+django-celery-beat
 django-celery-results
 
 

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -41,7 +41,7 @@ cron-descriptor==2.0.6
     # via django-celery-beat
 decorator==5.2.1
     # via retry2
-django==4.1.13
+django==4.2.24
     # via
     #   -r requirements.in
     #   django-autocomplete-light
@@ -51,13 +51,13 @@ django==4.1.13
     #   django-timezone-field
 django-autocomplete-light==3.12.1
     # via -r requirements.in
-django-celery-beat==2.5.0
+django-celery-beat==2.8.1
     # via -r requirements.in
 django-celery-results==2.6.0
     # via -r requirements.in
-django-cleanup==6.0.0
+django-cleanup==9.0.0
     # via -r requirements.in
-django-redis==5.4.0
+django-redis==6.0.0
     # via -r requirements.in
 django-timezone-field==7.1
     # via django-celery-beat

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -14,18 +14,18 @@ aiosignal==1.4.0
     # via aiohttp
 amqp==5.3.1
     # via kombu
-asgiref==3.9.1
+asgiref==3.9.2
     # via django
 attrs==25.3.0
     # via aiohttp
-billiard==3.6.4.0
+billiard==4.2.2
     # via celery
-celery[redis]==5.2.3
+celery[redis]==5.5.3
     # via
     #   -r requirements.in
     #   django-celery-beat
     #   django-celery-results
-click==8.2.1
+click==8.3.0
     # via
     #   celery
     #   click-didyoumean
@@ -41,26 +41,27 @@ cron-descriptor==2.0.6
     # via django-celery-beat
 decorator==5.2.1
     # via retry2
-django==4.0.10
+django==4.1.13
     # via
     #   -r requirements.in
     #   django-autocomplete-light
     #   django-celery-beat
+    #   django-celery-results
     #   django-redis
     #   django-timezone-field
 django-autocomplete-light==3.12.1
     # via -r requirements.in
 django-celery-beat==2.5.0
     # via -r requirements.in
-django-celery-results==2.4.0
+django-celery-results==2.6.0
     # via -r requirements.in
 django-cleanup==6.0.0
     # via -r requirements.in
-django-redis==5.2.0
+django-redis==5.4.0
     # via -r requirements.in
 django-timezone-field==7.1
     # via django-celery-beat
-django-widget-tweaks==1.4.12
+django-widget-tweaks==1.5.0
     # via -r requirements.in
 frozenlist==1.7.0
     # via
@@ -68,13 +69,13 @@ frozenlist==1.7.0
     #   aiosignal
 idna==3.10
     # via yarl
-kombu==5.5.4
+kombu[redis]==5.5.4
     # via celery
 language-tags==1.2.0
     # via lgr-core
 lgr-core @ git+https://github.com/icann/lgr-core.git@v6.1.3
     # via -r requirements.in
-lxml==6.0.1
+lxml==6.0.2
     # via lgr-core
 multidict==6.6.4
     # via
@@ -86,7 +87,7 @@ munidata==2.5.0
     #   lgr-core
 natsort==8.4.0
     # via -r requirements.in
-okta-jwt-verifier==0.2.9
+okta-jwt-verifier==0.3.0
     # via -r requirements.in
 packaging==25.0
     # via kombu
@@ -107,14 +108,16 @@ pyjwt==2.10.1
     # via okta-jwt-verifier
 python-crontab==3.3.0
     # via django-celery-beat
-pytz==2025.2
+python-dateutil==2.9.0.post0
     # via celery
-redis==3.5.3
+redis==5.2.1
     # via
-    #   celery
     #   django-redis
+    #   kombu
 retry2==0.9.5
     # via okta-jwt-verifier
+six==1.17.0
+    # via python-dateutil
 sqlparse==0.5.3
     # via django
 typing-extensions==4.15.0
@@ -127,11 +130,10 @@ tzdata==2025.2
     #   kombu
 vine==5.1.0
     # via
-    #   -r requirements.in
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.2.14
     # via prompt-toolkit
 yarl==1.20.1
     # via aiohttp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,17 @@ dependencies = [
     "picu",
     "vine"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers=[
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.1",
+    "Framework :: Django :: 4.2",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    #"Programming Language :: Python :: 3.12", #TODO: Test
+    #"Programming Language :: Python :: 3.13", #TODO: Test
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
References:
[Release notes of Django 4.1](https://docs.djangoproject.com/en/dev/releases/4.1/)
[Release notes of Django 4.2](https://docs.djangoproject.com/en/dev/releases/4.2/)

There was no changes that really impacted lgr-django when moving from 4.0 → 4.1 → 4.2, so this PR combines both.

The highlights:
- Update Django and other adjacent dependencies
- Remove Python 3.9 support
- Remove vine from readme
  - The codebase doesn't use it directly. It is still present in the requirements file.