### PR TITLE
Fix: logout is not submitted using POST

### DIFF
--- a/src/lgr_web/assets/chrome/css/lgr.css
+++ b/src/lgr_web/assets/chrome/css/lgr.css
@@ -457,3 +457,28 @@ a.panel {
     justify-content: space-between;
     flex-direction: row;
 }
+
+/* Logout Button
+.log-out-button must look like .dropdown-menu > li > a
+*/
+
+.log-out-button {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: 400;
+    line-height: 1.42857143;
+    color: #333333;
+    white-space: nowrap;
+
+    background: none;
+    border: none;
+    width: 100%;
+}
+
+.log-out-button:hover,
+.log-out-button:focus {
+    color: #262626;
+    text-decoration: none;
+    background-color: #f5f5f5;
+}

--- a/src/lgr_web/templates/_base.html
+++ b/src/lgr_web/templates/_base.html
@@ -115,10 +115,13 @@
                                     </a>
                                 </li>
                                 <li class="dropdown-item">
-                                    <a class="btn" href="{% url 'logout' %}">
-                                        <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
-                                        {% trans 'Logout' %}
-                                    </a>
+                                    <form method="POST" action="{% url 'logout' %}">
+                                        {% csrf_token %}
+                                        <button type="submit" class="log-out-button">
+                                            <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
+                                            {% trans 'Logout' %}
+                                        </button>
+                                    </form>
                                 </li>
                             </ul>
                             </div>


### PR DESCRIPTION
Prior to Django 4.1, it was possible to logout by calling the view with the GET method. However, this is not possible on later versions of Django ([see release notes](https://docs.djangoproject.com/en/5.2/releases/4.1/#log-out-via-get))

A change was missed in regards to the html which would cause an error when trying to log out.