### PR TITLE
Fix: Replace dictsort template filter

### DIFF
--- a/src/lgr_advanced/lgr_editor/templates/lgr_editor/_list_opened_lgrs.html
+++ b/src/lgr_advanced/lgr_editor/templates/lgr_editor/_list_opened_lgrs.html
@@ -1,6 +1,6 @@
-{% load i18n %}
+{% load i18n lgr_advanced%}
 
-{% regroup lgrs|dictsort:"is_set" by is_set as lgrs_sorted %}
+{% regroup lgrs|sort_by_is_set by group_key as lgrs_sorted %}
 <ul>
     {% for local_lgrs in lgrs_sorted %}
         {% if local_lgrs.grouper %}

--- a/src/lgr_advanced/templates/lgr_advanced/index.html
+++ b/src/lgr_advanced/templates/lgr_advanced/index.html
@@ -1,11 +1,11 @@
 {% extends "lgr_advanced/_base.html" %}
-{% load i18n %}
+{% load i18n lgr_advanced %}
 
 {% block content-title %}
     {% trans "Advanced LGR (Label Generation Ruleset) Tools" %}
 {% endblock %}
 {% block content %}
-    {% regroup lgrs|dictsort:"is_set" by is_set as lgrs_sorted %}
+    {% regroup lgrs|sort_by_is_set by group_key as lgrs_sorted %}
     <p>
     {% blocktrans trimmed %}
         This application provides a convenient interface for browsing

--- a/src/lgr_advanced/templatetags/lgr_advanced.py
+++ b/src/lgr_advanced/templatetags/lgr_advanced.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from django import template
+from django.db.models import QuerySet
+
+from lgr_advanced.models import LgrModel
+
+register = template.Library()
+
+
+@register.filter
+def sort_by_is_set(lgrs: QuerySet[LgrModel]) -> List[LgrModel]:
+    for instance in lgrs:
+        instance.group_key = instance.is_set()
+
+    return sorted(lgrs, key=lambda lgr: lgr.group_key)


### PR DESCRIPTION
The list of LGRs would not show in thepage `Advanced LGR (Label Generation Ruleset) Tools`.

`dictsort` does not call methods like `is_set()` anymore. This is due to a breaking change not documented in the major/minor realease, but in a fix version ([see related note](https://docs.djangoproject.com/en/dev/releases/4.0.1/#cve-2021-45116-potential-information-disclosure-in-dictsort-template-filter)).